### PR TITLE
Update tests and remove print stmt

### DIFF
--- a/admin_confirm/admin.py
+++ b/admin_confirm/admin.py
@@ -135,7 +135,6 @@ class AdminConfirmMixin:
                     if initial_value != new_value:
                         changed_data[name] = [initial_value, new_value]
 
-        print(changed_data)
         return changed_data
 
     def _get_form_data(self, request):


### PR DESCRIPTION
Making the m2m tests more comprehensive by checking the updated values of ShoppingMall and ensuring that the save action is conserved on confirmation page.