### PR TITLE
fix(ISSUE-8): try using admin form

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,16 @@ package:
 	python3 setup.py sdist bdist_wheel
 
 upload-testpypi:
-	python3 -m twine upload --repository testpypi dist/django_admin_confirm-$(VERSION)
+	python3 -m twine upload --repository testpypi dist/django_admin_confirm-$(VERSION)*
 
 i-have-tested-with-testpypi-and-am-ready-to-release:
-	python3 -m twine upload --repository pypi dist/django_admin_confirm-$(VERSION)
+	python3 -m twine upload --repository pypi dist/django_admin_confirm-$(VERSION)*
 
 install-testpypi:
+	pip uninstall django_admin_confirm
+	python -m pip install --index-url https://test.pypi.org/simple/ django_admin_confirm==${VERSION}
+
+testpypi:
+	python3 -m twine upload --repository testpypi dist/django_admin_confirm-$(VERSION)*
 	pip uninstall django_admin_confirm
 	python -m pip install --index-url https://test.pypi.org/simple/ django_admin_confirm==${VERSION}

--- a/admin_confirm/admin.py
+++ b/admin_confirm/admin.py
@@ -142,17 +142,26 @@ class AdminConfirmMixin:
         Parses the request post params into a format that can be used for the hidden form on the
         change confirmation page.
         """
-        form_data = request.POST.copy()
+        query_dict = request.POST.copy()
+        # Note: Do not use QueryDict.get(), it returns only the last value for multivalues
 
         for key in SAVE_ACTIONS + [
             "_confirm_change",
             "_confirm_add",
             "csrfmiddlewaretoken",
         ]:
-            if form_data.get(key):
-                form_data.pop(key)
+            if query_dict.get(key):
+                query_dict.pop(key)
 
-        form_data = [(k, list(v)) for k, v in form_data.lists()]
+        form_data = []
+        for k, v in query_dict.lists():
+            if isinstance(v, list):
+                for value in v:
+                    form_data.append((k, value))
+            else:
+                form_data.append((k, v))
+
+        # form_data = [(k, v) for k, v in form_data.lists()]
         return form_data
 
     def _change_confirmation_view(self, request, object_id, form_url, extra_context):

--- a/admin_confirm/static/admin/css/confirmation.css
+++ b/admin_confirm/static/admin/css/confirmation.css
@@ -1,24 +1,28 @@
 .submit-row a.cancel-link {
-    display: block;
-    background: #ba2121;
-    border-radius: 4px;
-    padding: 10px 15px;
-    height: 15px;
-    line-height: 15px;
-    color: #fff;
+  display: block;
+  background: #ba2121;
+  border-radius: 4px;
+  padding: 10px 15px;
+  height: 15px;
+  line-height: 15px;
+  color: #fff;
 }
 
 .submit-row a.cancel-link:focus,
 .submit-row a.cancel-link:hover,
 .submit-row a.cancel-link:active {
-    background: #a41515;
+  background: #a41515;
 }
 
 .changed-data table {
-    width: 100%;
+  width: 100%;
 }
 .changed-data th,
 .changed-data td {
-    width: 30%;
-    white-space: nowrap;
+  width: 30%;
+  white-space: nowrap;
+}
+
+.hidden {
+  display: none;
 }

--- a/admin_confirm/templates/admin/change_confirmation.html
+++ b/admin_confirm/templates/admin/change_confirmation.html
@@ -43,10 +43,8 @@
     <form method="post" action="{% url opts|admin_urlname:'change' object_id|admin_urlquote %}">{% csrf_token %}
   {% endif %}
 
-    {% for key, values in form_data %}
-        {% for v in values %}
-        <input type="hidden" name="{{ key }}" value="{{v}}">
-        {% endfor %}
+    {% for key, value in form_data %}
+        <input type="hidden" name="{{ key }}" value="{{value}}">
     {% endfor %}
     {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1">{% endif %}
     {% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}">{% endif %}

--- a/admin_confirm/templates/admin/change_confirmation.html
+++ b/admin_confirm/templates/admin/change_confirmation.html
@@ -42,10 +42,9 @@
     {% include "admin/change_data.html" %}
     <form method="post" action="{% url opts|admin_urlname:'change' object_id|admin_urlquote %}">{% csrf_token %}
   {% endif %}
-
-    {% for key, value in form_data %}
-        <input type="hidden" name="{{ key }}" value="{{value}}">
-    {% endfor %}
+    <div class=hidden>
+        {{ form }}
+    </div>
     {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1">{% endif %}
     {% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}">{% endif %}
     <div class="submit-row">

--- a/admin_confirm/tests/helpers.py
+++ b/admin_confirm/tests/helpers.py
@@ -1,0 +1,40 @@
+from django.test import TestCase, RequestFactory
+from django.contrib.auth.models import User
+
+
+class ConfirmAdminTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username="super", email="super@email.org", password="pass"
+        )
+
+    def setUp(self):
+        self.client.force_login(self.superuser)
+        self.factory = RequestFactory()
+
+    def _assertManyToManyFormHtml(self, rendered_content, options, selected_ids):
+        # Form data should be embedded and hidden on confirmation page
+        # Should have the correct ManyToMany options selected
+        for option in options:
+            self.assertIn(
+                f'<option value="{option.id}"{" selected" if option.id in selected_ids else ""}>{str(option)}</option>',
+                rendered_content,
+            )
+        # ManyToManyField should be embedded
+        self.assertIn("related-widget-wrapper", rendered_content)
+
+    def _assertSubmitHtml(self, rendered_content, save_action="_save"):
+        # Submit should conserve the save action
+        self.assertIn(
+            f'<input type="submit" value="Yes, I’m sure" name="{save_action}">',
+            rendered_content,
+        )
+        # There should not be _confirm_add or _confirm_change sent in the form on confirmaiton page
+        self.assertNotIn("_confirm_add", rendered_content)
+        self.assertNotIn("_confirm_change", rendered_content)
+
+    def _assertSimpleFieldFormHtml(self, rendered_content, fields):
+        for k, v in fields.items():
+            self.assertIn(f'name="{k}"', rendered_content)
+            self.assertIn(f'value="{v}"', rendered_content)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(here, "README.md")).read()
 
 setup(
     name="django-admin-confirm",
-    version="0.2.3.dev4",
+    version="0.2.3.dev5",
     packages=["admin_confirm"],
     description="Adds confirmation to Django Admin changes, additions and actions",
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Related to #8 


**Context**
Previously tried solutions:
1. initial state used `getattr` which returned a weird obj for m2m fields (v0.2.2)
2. next solution used `QueryDict.get` but that only returns that last value for a multivalue field
3. then tried to use `QueryDict.lists()` but I was using `list()` on the values which broke ImageField and FileField which worked with v0.2.2

Then I tried to unwrap lists and pass to template - this worked for m2m and simple fields. I did not test on ImageField and FileField. 

THEN.... I read this: https://stackoverflow.com/questions/26514892/how-to-pass-parameter-from-form-post-to-view-in-django-python

🤦 I didn't know you could do that.. and turns out that this line was already giving us the form HTML.... 


https://github.com/TrangPham/django-admin-confirm/blob/main/admin_confirm/admin.py#L188


Also see here, this is the important part of the code which confirmation view calls:

https://github.com/django/django/blob/master/django/contrib/admin/options.py#L1575-L1592

**TL;DR**
Anyhow, so this takes the form which the change view does show, but this would have the items that you changed in the `request.POST`, and then hides it with CSS. This should mean that this should be more compatible with Django and stay more compatible overtime. 

**TODO**
[ ] Tests for FileField and ImageField still need to be added. 
[ ] Tests for modified forms IE custom forms, setting `ModelAdmin.form` or overriding `ModelAdmin.get_form()`


