### PR TITLE
Fixing a missing import from the code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Note: `confirmation_fields` apply to both add/change confirmations.
 
 ```py
     from admin_confirm import AdminConfirmMixin
+    from admin_confirm.admin import confirm_action
 
     class MyModelAdmin(AdminConfirmMixin, ModelAdmin):
         actions = ["action1", "action2"]


### PR DESCRIPTION
The import could probably be neater if this is a first-class export, but that's not up to me to decide.

## Fixes 
- Readme is missing the import for the confirm_action decorator

## Proposed changes:
- Import it ;)