### PR TITLE
add admin actions description, if it exists (#58)

### DIFF
--- a/admin_confirm/admin.py
+++ b/admin_confirm/admin.py
@@ -460,8 +460,9 @@ def confirm_action(func):
         # get_actions will only return the actions that are allowed
         has_perm = modeladmin.get_actions(request).get(func.__name__) is not None
 
-        action_display_name = snake_to_title_case(func.__name__)
-        title = f"Confirm Action: {action_display_name}"
+        __, __, action_display_name = modeladmin.get_action(request.POST['action'])
+
+        title = f"{_('Confirm Action')}: {action_display_name}"
 
         context = {
             **modeladmin.admin_site.each_context(request),

--- a/admin_confirm/tests/unit/test_confirm_actions.py
+++ b/admin_confirm/tests/unit/test_confirm_actions.py
@@ -278,3 +278,16 @@ class TestConfirmActions(TestCase):
         self.assertEqual(expected_template, actual_template)
         # Clear our setting to not affect other tests
         ShopAdmin.action_confirmation_template = None
+
+    def test_action_confirm_title_equal_description_field(self):
+        response = self.client.post(
+            reverse("admin:market_shop_changelist"),
+            data={
+                "action": ["show_description"],
+                "select_across": ["0"],
+                "index": ["0"],
+                "_selected_action": ["3", "2", "1"],
+            },
+            follow=True,
+        )
+        self.assertIn("Confirm Action: foobar description", response.rendered_content)

--- a/tests/market/admin/shop_admin.py
+++ b/tests/market/admin/shop_admin.py
@@ -1,10 +1,13 @@
+from django.contrib import admin
 from django.contrib.admin import ModelAdmin
 from admin_confirm import AdminConfirmMixin, confirm_action
 
 
 class ShopAdmin(AdminConfirmMixin, ModelAdmin):
     confirmation_fields = ["name"]
-    actions = ["show_message", "show_message_no_confirmation"]
+    actions = [
+        "show_message", "show_message_no_confirmation", "show_description"
+    ]
     search_fields = ["name"]
 
     @confirm_action
@@ -20,3 +23,8 @@ class ShopAdmin(AdminConfirmMixin, ModelAdmin):
 
     def has_delete_permission(self, request, obj=None):
         return request.user.is_superuser
+
+    @confirm_action
+    @admin.action(description='foobar description')
+    def show_description(modeladmin, request, queryset):
+        pass


### PR DESCRIPTION
## Fixes 
- #58 

## Proposed changes:
- add description from @admin.action(description=)

## Tested via:
- unit
