### PR TITLE
Move refresh_from_db outside of loop

### DIFF
--- a/admin_confirm/admin.py
+++ b/admin_confirm/admin.py
@@ -184,12 +184,13 @@ class AdminConfirmMixin:
                         field_object, default_value, new_value
                     )
         else:
+            # Since the form considers initial as the value first shown in the form
+            # It could be incorrect when user hits save, and then hits "No, go back to edit"
+            obj.refresh_from_db()
+
             # Parse the changed data - Note that using form.changed_data would not work because initial is not set
             for name, new_value in form.cleaned_data.items():
 
-                # Since the form considers initial as the value first shown in the form
-                # It could be incorrect when user hits save, and then hits "No, go back to edit"
-                obj.refresh_from_db()
 
                 field_object = model._meta.get_field(name)
                 initial_value = getattr(obj, name)


### PR DESCRIPTION
## Fixes 
`obj.refresh_from_db()` is called for every item in a form. In my case that lead to the same query for fetching an object being executed 8 times, even though once would have been enough.

I haven't added an issue for that, as I had the impression adding an issue and adding steps to reproduce were more complicated than just directly fixing the issue.

## Tested via:
No tests added, as functionality facing the end user did not change and this is purely a performance related improvement. I could add a unit test checking the amount of queries executed if needed.


Please tell me if more information on this issue is needed or whether this description is sufficient.