### PR TITLE
Fix bug with field names

### DIFF
--- a/admin_confirm/admin.py
+++ b/admin_confirm/admin.py
@@ -434,7 +434,6 @@ class AdminConfirmMixin:
             "app_label": opts.app_label,
             "model_name": opts.model_name,
             "opts": opts,
-            "obj": obj,
             "changed_data": changed_data,
             "add": add,
             "save_as_new": SAVE_AS_NEW in request.POST,

--- a/admin_confirm/templates/admin/change_data.html
+++ b/admin_confirm/templates/admin/change_data.html
@@ -9,7 +9,7 @@
     </tr>
     {% for field, values in changed_data.items %}
     <tr>
-      <td>{% verbose_name obj field %}</td>
+      <td>{% verbose_name opts field %}</td>
       <td>{{ values.0|format_change_data_field_value }}</td>
       <td>{{ values.1|format_change_data_field_value }}</td>
     </tr>

--- a/admin_confirm/templatetags/formatting.py
+++ b/admin_confirm/templatetags/formatting.py
@@ -20,6 +20,7 @@ def format_change_data_field_value(field_value):
 
 
 @register.simple_tag
-def verbose_name(obj, fieldname):
-    if obj:
-        return obj._meta.get_field(fieldname).verbose_name
+def verbose_name(opts, fieldname):
+    # opts is set within context and is equal to model._meta
+    if opts:
+        return opts.get_field(fieldname).verbose_name

--- a/admin_confirm/tests/unit/test_fieldsets.py
+++ b/admin_confirm/tests/unit/test_fieldsets.py
@@ -1,6 +1,6 @@
 """
 Tests ModelAdmin with fieldsets custom configured through one of the possible methods
-Ensures that AdminConfirmMixin works correctly when implimenting class alters default fieldsets
+Ensures that AdminConfirmMixin works correctly when implementing class alters default fieldsets
 
 Test Matrix
 method: `.fieldsets =`, `def get_fieldsets()`

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,6 +31,7 @@ services:
 
   selenium:
     image: selenium/standalone-firefox
+    platform: linux/amd64
     ports:
       - "4444:4444" # Selenium
       - "5900:5900" # VNC

--- a/docs/development_process.md
+++ b/docs/development_process.md
@@ -83,6 +83,9 @@ docker-compose -f docker-compose.dev.yml up -d
 
 You should now be able to see the app running on `localhost:8000`
 
+> Note:
+> If you get NoSuchBucket error in the web container, execute `awslocal s3 mb s3://mybucket` in the localstack container and restart web container.
+
 If you haven't already done migrations and created a superuser, you'll want to do it here
 
 ```
@@ -136,4 +139,4 @@ make run
 
 Go on github and make a release in UI
 
-To update supported version badges, use https://shields.io
+To update supported version badges, use <https://shields.io>

--- a/tests/market/admin/transaction_admin.py
+++ b/tests/market/admin/transaction_admin.py
@@ -2,8 +2,15 @@ from admin_confirm.admin import AdminConfirmMixin
 
 
 from django.contrib.admin import ModelAdmin
+from django.contrib import admin
 
 
 class TransactionAdmin(AdminConfirmMixin, ModelAdmin):
     confirm_add = True
     confirm_change = True
+
+    readonly_fields = ["my_custom_field"]
+
+    @admin.display(description="Custom Field")
+    def my_custom_field(self, obj):
+        return "Static Custom Field Value"


### PR DESCRIPTION
## Fixes 

#31 introduced a bug where field names were None within the confirm add change data. This was due to obj being None on add since the obj does not exist yet.

## Other changes:
- added an example for custom field for the fix from #57 and manually tested it
- typo fix
- update readme

## Tested via:
- Tested manually

Added custom field
![Screenshot 2025-03-05 at 12 56 08 PM](https://github.com/user-attachments/assets/b720dc55-bf95-49bf-935d-70671f600b3c)
Before fixing bug from #31 
![Screenshot 2025-03-05 at 12 58 39 PM](https://github.com/user-attachments/assets/b69f4e97-beb4-4dc6-a42f-0d8eb3e3c0e0)
After fixing the bug
![Screenshot 2025-03-05 at 12 57 49 PM](https://github.com/user-attachments/assets/5365b276-4aee-4477-9e0c-7f35ac97d015)


