### PR TITLE
ISSUE-48: Include M2M in default confirmation fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,4 +5,5 @@
 - Prefer working on default git worktree. When starting new work, ask user if they want to stash changes and start on a new branch off of main.
 - Prefer fully spelled out variables instead of 1-3 character variables. Prefer shorter methods which read like english.
 - When code might not be fully self-explainatory, include a human readable short comment with context.
-- Please read the development guide and make use of makefile commands whenever possible.
+- Please read the development guide and make use of makefile commands whenever possible. For example don't do: `python -m pytest admin_confirm/tests/integration/test_with_inlines.py::ConfirmWithInlinesTests::test_should_have_saved_inline_changes -q` and instead use `make docker-test ARGS=...` Note: before running tests, make sure docker is running, use `make docker-build && make docker-up`
+- AVOID any non-functional churn such as formatting, whitespace changes, etc unless the user specifically asked you for it.

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ docker-build:
 	docker compose -f docker-compose.dev.yml build
 
 docker-test:
-	docker compose -f docker-compose.dev.yml exec -T web pytest --ignore=admin_confirm/tests/integration
+	docker compose -f docker-compose.dev.yml exec -T web pytest ${ARGS}
 
 docker-test-all:
 	make docker-exec COMMAND="make test-all"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ docker-build:
 	docker compose -f docker-compose.dev.yml build
 
 docker-test:
-	docker compose -f docker-compose.dev.yml exec -T web pytest ${ARGS}
+	docker compose -f docker-compose.dev.yml exec -T web python -m pytest ${ARGS}
 
 docker-test-all:
 	make docker-exec COMMAND="make test-all"

--- a/admin_confirm/admin.py
+++ b/admin_confirm/admin.py
@@ -175,11 +175,29 @@ class AdminConfirmMixin:
                     # Don't consider default values as changed for adding
                     field_object = model._meta.get_field(name)
                     default_value = field_object.get_default()
-                    if new_value is not None and new_value != default_value:
-                        # Show what the default value is
-                        changed_data[name] = _display_for_changed_data(
-                            field_object, default_value, new_value
+                    if isinstance(field_object, ManyToManyField):
+                        default_value_pks = (
+                            set([item.pk for item in default_value]) if default_value else set()
                         )
+                        new_value_pks = (
+                            set(new_value.values_list("pk", flat=True)) if new_value else set()
+                        )
+                        log(
+                            f"ManyToManyField {name} default PKs are {default_value_pks} and new value PKs are {new_value_pks}"
+                        )
+                        log(
+                            f"ManyToManyField {name} has changed from {default_value} to {new_value}"
+                        )
+                        if default_value_pks != new_value_pks:
+                            changed_data[name] = _display_for_changed_data(
+                                field_object, default_value, new_value
+                            )
+                    else:
+                        if new_value is not None and new_value != default_value:
+                            # Show what the default value is
+                            changed_data[name] = _display_for_changed_data(
+                                field_object, default_value, new_value
+                            )
         else:
             # Since the form considers initial as the value first shown in the form
             # It could be incorrect when user hits save, and then hits "No, go back to edit"

--- a/admin_confirm/admin.py
+++ b/admin_confirm/admin.py
@@ -194,7 +194,9 @@ class AdminConfirmMixin:
 
                     if isinstance(field_object, ManyToManyField):
                         initial_value = field_object.value_from_object(obj)
-                        initial_value_pks = set(initial_value)
+                        initial_value_pks = set(
+                            [initial_value_item.pk for initial_value_item in initial_value]
+                        )
                         new_value_pks = set(new_value.values_list("pk", flat=True))
                         if initial_value_pks != new_value_pks:
                             log(

--- a/admin_confirm/admin.py
+++ b/admin_confirm/admin.py
@@ -9,7 +9,7 @@ from django.template.response import TemplateResponse
 from django.contrib.admin.options import TO_FIELD_VAR
 from django.utils.translation import gettext as _
 from django.contrib.admin import helpers
-from django.db.models import Model, ManyToManyField, FileField, ImageField
+from django.db.models import Model, ManyToManyField, FileField, ImageField, QuerySet
 from django.forms import ModelForm
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control
@@ -53,9 +53,7 @@ class AdminConfirmMixin:
         Hook for specifying confirmation fields
         """
         # default confirmation fields to all fields, including ManyToManyFields
-        confirmation_fields = set(
-            [field.name for field in self.model._meta.get_fields() if not field.auto_created]
-        )
+        confirmation_fields = set(field.name for field in self.model._meta.get_fields())
 
         if self.confirmation_fields and self.confirmation_fields != "__all__":
             # set confirmation fields if specified
@@ -190,11 +188,14 @@ class AdminConfirmMixin:
                 with suppress(FieldDoesNotExist):
 
                     field_object = model._meta.get_field(name)
-                    initial_value = getattr(obj, name)
 
                     # Note: getattr does not work on ManyToManyFields
                     if isinstance(field_object, ManyToManyField):
                         initial_value = field_object.value_from_object(obj)
+                        if isinstance(new_value, QuerySet):
+                            new_value = list(new_value)
+                    else:
+                        initial_value = getattr(obj, name)
 
                     if initial_value != new_value:
                         changed_data[name] = _display_for_changed_data(

--- a/admin_confirm/admin.py
+++ b/admin_confirm/admin.py
@@ -9,7 +9,7 @@ from django.template.response import TemplateResponse
 from django.contrib.admin.options import TO_FIELD_VAR
 from django.utils.translation import gettext as _
 from django.contrib.admin import helpers
-from django.db.models import Model, ManyToManyField, FileField, ImageField, QuerySet
+from django.db.models import ForeignKey, Model, ManyToManyField, FileField, ImageField, QuerySet
 from django.forms import ModelForm
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control
@@ -53,7 +53,9 @@ class AdminConfirmMixin:
         Hook for specifying confirmation fields
         """
         # default confirmation fields to all fields, including ManyToManyFields
-        confirmation_fields = set(field.name for field in self.model._meta.get_fields())
+        confirmation_fields = set([field.name for field in self.model._meta.fields]) | set(
+            field.name for field in self.model._meta.get_fields()
+        )
 
         if self.confirmation_fields and self.confirmation_fields != "__all__":
             # set confirmation fields if specified
@@ -61,6 +63,7 @@ class AdminConfirmMixin:
 
         # filter to valid fields which are visible on the admin page
         admin_fields = set(flatten_fieldsets(self.get_fieldsets(request, obj)))
+        log(f"Admin fields are {admin_fields} and confirmation fields are {confirmation_fields}")
         return list(confirmation_fields & admin_fields)
 
     def render_change_confirmation(self, request, context):
@@ -189,18 +192,37 @@ class AdminConfirmMixin:
 
                     field_object = model._meta.get_field(name)
 
-                    # Note: getattr does not work on ManyToManyFields
                     if isinstance(field_object, ManyToManyField):
                         initial_value = field_object.value_from_object(obj)
-                        if isinstance(new_value, QuerySet):
-                            new_value = list(new_value)
+                        initial_value_pks = set(initial_value)
+                        new_value_pks = set(new_value.values_list("pk", flat=True))
+                        if initial_value_pks != new_value_pks:
+                            log(
+                                f"ManyToManyField {name} has changed from {initial_value_pks} to {new_value_pks}"
+                            )
+                            changed_data[name] = _display_for_changed_data(
+                                field_object, initial_value, new_value
+                            )
+                    elif isinstance(field_object, ForeignKey):
+                        initial_value = getattr(obj, name)
+                        initial_pk = (
+                            initial_value.pk if isinstance(initial_value, Model) else initial_value
+                        )
+                        new_pk = new_value.pk if isinstance(new_value, Model) else new_value
+
+                        if initial_pk != new_pk:
+                            log(f"Field {name} PK has changed from {initial_pk} to {new_pk}")
+                            changed_data[name] = _display_for_changed_data(
+                                field_object, initial_value, new_value
+                            )
                     else:
                         initial_value = getattr(obj, name)
 
-                    if initial_value != new_value:
-                        changed_data[name] = _display_for_changed_data(
-                            field_object, initial_value, new_value
-                        )
+                        if initial_value != new_value:
+                            log(f"Field {name} has changed from {initial_value} to {new_value}")
+                            changed_data[name] = _display_for_changed_data(
+                                field_object, initial_value, new_value
+                            )
 
         return changed_data
 
@@ -375,9 +397,12 @@ class AdminConfirmMixin:
         # Get changed data to show on confirmation
         changed_data = self._get_changed_data(form, model, obj, add_or_new)
 
-        changed_confirmation_fields = set(self.get_confirmation_fields(request, obj)) & set(
-            changed_data.keys()
+        confirmation_fields = self.get_confirmation_fields(request, obj)
+        changed_confirmation_fields = set(confirmation_fields) & set(changed_data.keys())
+        log(
+            f"Confirmation fields are {confirmation_fields} and changed data fields are {changed_data.keys()}"
         )
+
         if not bool(changed_confirmation_fields):
             log("No change detected")
             # No confirmation required for changed fields, continue to save

--- a/admin_confirm/admin.py
+++ b/admin_confirm/admin.py
@@ -52,8 +52,10 @@ class AdminConfirmMixin:
         """
         Hook for specifying confirmation fields
         """
-        # default confirmation fields to all fields
-        confirmation_fields = set([field.name for field in self.model._meta.fields])
+        # default confirmation fields to all fields, including ManyToManyFields
+        confirmation_fields = set(
+            [field.name for field in self.model._meta.get_fields() if not field.auto_created]
+        )
 
         if self.confirmation_fields and self.confirmation_fields != "__all__":
             # set confirmation fields if specified

--- a/admin_confirm/admin.py
+++ b/admin_confirm/admin.py
@@ -9,7 +9,7 @@ from django.template.response import TemplateResponse
 from django.contrib.admin.options import TO_FIELD_VAR
 from django.utils.translation import gettext as _
 from django.contrib.admin import helpers
-from django.db.models import ForeignKey, Model, ManyToManyField, FileField, ImageField, QuerySet
+from django.db.models import ForeignKey, Model, ManyToManyField, FileField, ImageField
 from django.forms import ModelForm
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control

--- a/admin_confirm/tests/helpers.py
+++ b/admin_confirm/tests/helpers.py
@@ -118,9 +118,8 @@ class AdminConfirmIntegrationTestCase(LiveServerTestCase):
         return super().tearDown()
 
     def setAdminAttributes(self, admin, **attrs):
-        for target in _get_admin_patch_targets(admin):
-            for attr, value in attrs.items():
-                self.exit_stack.enter_context(mock.patch.object(target, attr, value))
+        for attr, value in attrs.items():
+            self.exit_stack.enter_context(mock.patch.object(target, attr, value))
 
     @classmethod
     def tearDownClass(cls):

--- a/admin_confirm/tests/helpers.py
+++ b/admin_confirm/tests/helpers.py
@@ -110,7 +110,7 @@ class AdminConfirmIntegrationTestCase(LiveServerTestCase):
             {"name": "sessionid", "value": cookie.value, "secure": False, "path": "/"}
         )
         return super().setUp()
-
+    
     def tearDown(self):
         self.exit_stack.close()
         cache.clear()

--- a/admin_confirm/tests/helpers.py
+++ b/admin_confirm/tests/helpers.py
@@ -2,6 +2,7 @@ from contextlib import ExitStack
 import socket
 from unittest import mock
 
+from django.contrib import admin as django_admin
 from django.core.cache import cache
 from django.test import TestCase, RequestFactory, LiveServerTestCase
 from django.contrib.auth.models import User
@@ -11,6 +12,25 @@ from selenium import webdriver
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.support.ui import Select
 from selenium.webdriver.common.by import By
+
+
+def _get_admin_patch_targets(admin):
+    """
+    Return admin objects to patch in tests.
+
+    Tests may hold a class reference that differs from the ModelAdmin instance
+    currently registered in Django admin. Patch both targets so test overrides
+    are applied consistently to the admin actually serving requests.
+    """
+    targets = [admin]
+    model = getattr(admin, "model", None)
+    if model:
+        # Django does not expose a public API for retrieving the registered
+        # ModelAdmin instance by model, so tests read from _registry directly.
+        registered_admin = django_admin.site._registry.get(model)
+        if registered_admin and registered_admin not in targets:
+            targets.append(registered_admin)
+    return targets
 
 
 class AdminConfirmTestCase(TestCase):
@@ -38,8 +58,9 @@ class AdminConfirmTestCase(TestCase):
         Helper method to set admin attributes with automatic cleanup after test
         If used in setUp(), must be called after super().setUp()
         """
-        for attr, value in attrs.items():
-            self.exit_stack.enter_context(mock.patch.object(admin, attr, value))
+        for target in _get_admin_patch_targets(admin):
+            for attr, value in attrs.items():
+                self.exit_stack.enter_context(mock.patch.object(target, attr, value))
 
     def _assertManyToManyFormHtml(self, rendered_content, options, selected_ids):
         # Form data should be embedded and hidden on confirmation page
@@ -117,8 +138,9 @@ class AdminConfirmIntegrationTestCase(LiveServerTestCase):
         return super().tearDown()
 
     def setAdminAttributes(self, admin, **attrs):
-        for attr, value in attrs.items():
-            self.exit_stack.enter_context(mock.patch.object(admin, attr, value))
+        for target in _get_admin_patch_targets(admin):
+            for attr, value in attrs.items():
+                self.exit_stack.enter_context(mock.patch.object(target, attr, value))
 
     @classmethod
     def tearDownClass(cls):

--- a/admin_confirm/tests/helpers.py
+++ b/admin_confirm/tests/helpers.py
@@ -14,25 +14,6 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.common.by import By
 
 
-def _get_admin_patch_targets(admin):
-    """
-    Return admin objects to patch in tests.
-
-    Tests may hold a class reference that differs from the ModelAdmin instance
-    currently registered in Django admin. Patch both targets so test overrides
-    are applied consistently to the admin actually serving requests.
-    """
-    targets = [admin]
-    model = getattr(admin, "model", None)
-    if model:
-        # Django does not expose a public API for retrieving the registered
-        # ModelAdmin instance by model, so tests read from _registry directly.
-        registered_admin = django_admin.site._registry.get(model)
-        if registered_admin and registered_admin not in targets:
-            targets.append(registered_admin)
-    return targets
-
-
 class AdminConfirmTestCase(TestCase):
     """
     Helper TestCase class and common associated assertions

--- a/admin_confirm/tests/helpers.py
+++ b/admin_confirm/tests/helpers.py
@@ -1,4 +1,6 @@
+from contextlib import ExitStack
 import socket
+from unittest import mock
 
 from django.core.cache import cache
 from django.test import TestCase, RequestFactory, LiveServerTestCase
@@ -26,6 +28,18 @@ class AdminConfirmTestCase(TestCase):
         cache.clear()
         self.client.force_login(self.superuser)
         self.factory = RequestFactory()
+        self.exit_stack = ExitStack()
+
+    def tearDown(self):
+        self.exit_stack.close()
+
+    def setAdminAttributes(self, admin, **attrs):
+        """
+        Helper method to set admin attributes with automatic cleanup after test
+        Can only be called in setUp after super().setUp()
+        """
+        for attr, value in attrs.items():
+            self.exit_stack.enter_context(mock.patch.object(admin, attr, value))
 
     def _assertManyToManyFormHtml(self, rendered_content, options, selected_ids):
         # Form data should be embedded and hidden on confirmation page
@@ -85,6 +99,7 @@ class AdminConfirmIntegrationTestCase(LiveServerTestCase):
             username="super", email="super@email.org", password="pass"
         )
         self.client.force_login(self.superuser)
+        self.exit_stack = ExitStack()
 
         cookie = self.client.cookies["sessionid"]
         self.selenium.get(
@@ -96,9 +111,14 @@ class AdminConfirmIntegrationTestCase(LiveServerTestCase):
         return super().setUp()
 
     def tearDown(self):
+        self.exit_stack.close()
         cache.clear()
         self.selenium.get(self.live_server_url)
         return super().tearDown()
+
+    def setAdminAttributes(self, admin, **attrs):
+        for attr, value in attrs.items():
+            self.exit_stack.enter_context(mock.patch.object(admin, attr, value))
 
     @classmethod
     def tearDownClass(cls):

--- a/admin_confirm/tests/helpers.py
+++ b/admin_confirm/tests/helpers.py
@@ -36,7 +36,7 @@ class AdminConfirmTestCase(TestCase):
     def setAdminAttributes(self, admin, **attrs):
         """
         Helper method to set admin attributes with automatic cleanup after test
-        Can only be called in setUp after super().setUp()
+        If used in setUp(), must be called after super().setUp()
         """
         for attr, value in attrs.items():
             self.exit_stack.enter_context(mock.patch.object(admin, attr, value))

--- a/admin_confirm/tests/helpers.py
+++ b/admin_confirm/tests/helpers.py
@@ -58,9 +58,8 @@ class AdminConfirmTestCase(TestCase):
         Helper method to set admin attributes with automatic cleanup after test
         If used in setUp(), must be called after super().setUp()
         """
-        for target in _get_admin_patch_targets(admin):
-            for attr, value in attrs.items():
-                self.exit_stack.enter_context(mock.patch.object(target, attr, value))
+        for attr, value in attrs.items():
+            self.exit_stack.enter_context(mock.patch.object(admin, attr, value))
 
     def _assertManyToManyFormHtml(self, rendered_content, options, selected_ids):
         # Form data should be embedded and hidden on confirmation page

--- a/admin_confirm/tests/helpers.py
+++ b/admin_confirm/tests/helpers.py
@@ -119,7 +119,7 @@ class AdminConfirmIntegrationTestCase(LiveServerTestCase):
 
     def setAdminAttributes(self, admin, **attrs):
         for attr, value in attrs.items():
-            self.exit_stack.enter_context(mock.patch.object(target, attr, value))
+            self.exit_stack.enter_context(mock.patch.object(admin, attr, value))
 
     @classmethod
     def tearDownClass(cls):

--- a/admin_confirm/tests/integration/test_with_cache.py
+++ b/admin_confirm/tests/integration/test_with_cache.py
@@ -6,7 +6,6 @@ on ModelAdmin that utilize caches
 import os
 import pytest
 
-from importlib import reload
 from importlib.metadata import version as get_version
 from tests.market.models import Item, ShoppingMall
 
@@ -26,7 +25,6 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         super().setUp()
 
     def tearDown(self):
-        reload(shoppingmall_admin)
         super().tearDown()
 
     def test_models_without_files_should_not_have_confirmation_received(self):
@@ -81,12 +79,6 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         item.refresh_from_db()
 
     def test_should_save_file_additions(self):
-        selenium_major = int(get_version("selenium").split(".")[0])
-        if selenium_major < 4:
-            pytest.skip(
-                "Known issue `https://github.com/SeleniumHQ/selenium/issues/8762` with this selenium version."
-            )
-
         item = Item.objects.create(name="item", price=1, currency=Item.VALID_CURRENCIES[0][0])
 
         self.selenium.get(self.live_server_url + f"/admin/market/item/{item.id}/change/")
@@ -115,12 +107,6 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         self.assertRegex(item.file.name, r"screenshot.*\.png$")
 
     def test_should_save_file_changes(self):
-        selenium_major = int(get_version("selenium").split(".")[0])
-        if selenium_major < 4:
-            pytest.skip(
-                "Known issue `https://github.com/SeleniumHQ/selenium/issues/8762` with this selenium version."
-            )
-
         with open("screenshot.png", "rb") as f:
             file = SimpleUploadedFile(
                 name="old_file.jpg",

--- a/admin_confirm/tests/integration/test_with_form_input_types.py
+++ b/admin_confirm/tests/integration/test_with_form_input_types.py
@@ -17,7 +17,7 @@ from selenium.webdriver.common.by import By
 
 class ConfirmWithFormInputTypes(AdminConfirmIntegrationTestCase):
     def setUp(self):
-        super().setUpClass()
+        super().setUp()
         self.setAdminAttributes(
             ItemAdmin,
             confirm_add=True,
@@ -31,7 +31,7 @@ class ConfirmWithFormInputTypes(AdminConfirmIntegrationTestCase):
             inlines=[]
         )
 
-    def tearDowns(self):
+    def tearDown(self):
         super().tearDown()
 
     def test_radio_input_should_work(self):

--- a/admin_confirm/tests/integration/test_with_form_input_types.py
+++ b/admin_confirm/tests/integration/test_with_form_input_types.py
@@ -4,12 +4,11 @@ Tests with different form input types
 
 from datetime import timedelta
 from django.utils import timezone
-from importlib import reload
 from tests.factories import ShopFactory, TransactionFactory
 from tests.market.models import GeneralManager, Item, ShoppingMall, Town
 
 from admin_confirm.tests.helpers import AdminConfirmIntegrationTestCase
-from tests.market.admin import item_admin, shoppingmall_admin
+from tests.market.admin import ItemAdmin, ShoppingMallAdmin
 
 from django.contrib.admin import VERTICAL
 from admin_confirm.constants import CONFIRM_ADD, CONFIRM_CHANGE
@@ -17,24 +16,23 @@ from selenium.webdriver.common.by import By
 
 
 class ConfirmWithFormInputTypes(AdminConfirmIntegrationTestCase):
-    @classmethod
-    def setUpClass(cls):
-        i_admin = item_admin.ItemAdmin
-        i_admin.confirm_add = True
-        i_admin.confirm_change = True
-        i_admin.confirmation_fields = ["currency", "price", "name"]
-        i_admin.radio_fields = {"currency": VERTICAL}
+    def setUp(self):
+        super().setUpClass()
+        self.setAdminAttributes(
+            ItemAdmin,
+            confirm_add=True,
+            confirm_change=True,
+            confirmation_fields=["currency", "price", "name"],
+            radio_fields={"currency":VERTICAL}
+        )
+        self.setAdminAttributes(
+            ShoppingMallAdmin,
+            raw_id_fields=["general_manager"],
+            inlines=[]
+        )
 
-        mall_admin = shoppingmall_admin.ShoppingMallAdmin
-        mall_admin.raw_id_fields = ["general_manager"]
-        mall_admin.inlines = []
-        return super().setUpClass()
-
-    @classmethod
-    def tearDownClass(cls):
-        reload(shoppingmall_admin)
-        reload(item_admin)
-        return super().tearDownClass()
+    def tearDowns(self):
+        super().tearDown()
 
     def test_radio_input_should_work(self):
         self.selenium.get(self.live_server_url + "/admin/market/item/add/")

--- a/admin_confirm/tests/integration/test_with_inlines.py
+++ b/admin_confirm/tests/integration/test_with_inlines.py
@@ -107,11 +107,6 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         self.assertIn(shops[2], mall.shops.all())
 
     def test_should_respect_get_inlines(self):
-        # New in Django 3.0
-        django_major = django.VERSION[0]
-        if django_major < 3:
-            pytest.skip("get_inlines() introducted in Django 3.0, and is not in this version")
-
         self.setAdminAttributes(
             ShoppingMallAdmin,
             inlines=[],

--- a/admin_confirm/tests/integration/test_with_inlines.py
+++ b/admin_confirm/tests/integration/test_with_inlines.py
@@ -187,3 +187,63 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         mall.refresh_from_db()
         self.assertIn("New Name", mall.name)
         self.assertIn(shops[2], mall.shops.all())
+
+    def test_detects_changes_to_m2m_fields(self):
+        # make the m2m the only confirmation_field
+        self.setAdminAttributes(shoppingmall_admin.ShoppingMallAdmin, confirmation_fields=["shops"])
+        shops = [ShopFactory() for i in range(3)]
+        shopping_mall = ShoppingMall.objects.create(name="name")
+        shopping_mall.refresh_from_db()
+        assert shopping_mall.shops.count() == 0
+
+        self.selenium.get(
+            self.live_server_url + f"/admin/market/shoppingmall/{shopping_mall.id}/change/"
+        )
+        self.assertIn(CONFIRM_CHANGE, self.selenium.page_source)
+
+        # Click on one of the shops in the m2m field to change it
+        select_shop = Select(self.selenium.find_element(By.NAME, "shops"))
+        select_shop.select_by_value(str(shops[0].id))
+
+        # Click save and continue to trigger confirmation page
+        self.selenium.find_element(By.NAME, "_continue").click()
+
+        # Should ask for confirmation since m2m field has changed
+        self.assertIn("Confirm", self.selenium.page_source)
+
+        # Shops has not changed until confirmation received
+        shopping_mall.refresh_from_db()
+        self.assertEqual(shopping_mall.shops.count(), 0)
+
+        # Click on "Yes, I'm sure" to confirm change
+        self.selenium.find_element(By.NAME, "_continue").click()
+
+        shopping_mall.refresh_from_db()
+        self.assertEqual(shopping_mall.shops.count(), 1)
+        self.assertIn(shops[0], shopping_mall.shops.all())
+
+    def test_does_not_trigger_confirmation_if_m2m_field_in_confirmation_fields_but_m2m_field_not_changed(
+        self,
+    ):
+        # make the m2m the only confirmation_field
+        self.setAdminAttributes(shoppingmall_admin.ShoppingMallAdmin, confirmation_fields=["shops"])
+        shops = [ShopFactory() for i in range(3)]
+        shopping_mall = ShoppingMall.objects.create(name="name")
+        shopping_mall.shops.set(shops)
+        shopping_mall.refresh_from_db()
+        assert shopping_mall.shops.count() == 3
+
+        self.selenium.get(
+            self.live_server_url + f"/admin/market/shoppingmall/{shopping_mall.id}/change/"
+        )
+        self.assertIn(CONFIRM_CHANGE, self.selenium.page_source)
+
+        # Do nothing and submit form
+        self.selenium.find_element(By.NAME, "_continue").click()
+
+        # Should not ask for confirmation since m2m field has not changed
+        self.assertNotIn("Confirm", self.selenium.page_source)
+
+        # Shops has not changed
+        shopping_mall.refresh_from_db()
+        self.assertEqual(shopping_mall.shops.count(), 3)

--- a/admin_confirm/tests/integration/test_with_inlines.py
+++ b/admin_confirm/tests/integration/test_with_inlines.py
@@ -11,7 +11,7 @@ from tests.factories import ShopFactory
 from tests.market.models import GeneralManager, ShoppingMall, Town
 
 from admin_confirm.tests.helpers import AdminConfirmIntegrationTestCase
-from tests.market.admin import shoppingmall_admin
+from tests.market.admin import ShoppingMallAdmin, ShopInline
 
 from admin_confirm.constants import CONFIRM_ADD, CONFIRM_CHANGE
 from selenium.webdriver.support.ui import Select
@@ -20,11 +20,10 @@ from selenium.webdriver.common.by import By
 
 class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
     def setUp(self):
-        self.admin = shoppingmall_admin.ShoppingMallAdmin
         super().setUp()
         self.setAdminAttributes(
-            shoppingmall_admin.ShoppingMallAdmin,
-            inlines=[shoppingmall_admin.ShopInline],
+            ShoppingMallAdmin,
+            inlines=[ShopInline],
         )
 
     def test_should_have_hidden_form(self):
@@ -114,9 +113,9 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
             pytest.skip("get_inlines() introducted in Django 3.0, and is not in this version")
 
         self.setAdminAttributes(
-            shoppingmall_admin.ShoppingMallAdmin,
+            ShoppingMallAdmin,
             inlines=[],
-            get_inlines=lambda self, request, obj=None: [shoppingmall_admin.ShopInline],
+            get_inlines=lambda self, request, obj=None: [ShopInline],
         )
 
         gm = GeneralManager.objects.create(name="gm")
@@ -150,11 +149,11 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
 
     def test_should_respect_get_inline_instances(self):
         self.setAdminAttributes(
-            shoppingmall_admin.ShoppingMallAdmin,
+            ShoppingMallAdmin,
             inlines=[],
-            get_inline_instances=lambda self, request, obj=None: shoppingmall_admin.ShopInline(
+            get_inline_instances=lambda self, request, obj=None: [ShopInline(
                 self.model, self.admin_site
-            ),
+            ),]
         )
         gm = GeneralManager.objects.create(name="gm")
         town = Town.objects.create(name="town")
@@ -187,7 +186,7 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
 
     def test_detects_changes_to_m2m_fields(self):
         # make the m2m the only confirmation_field
-        self.setAdminAttributes(shoppingmall_admin.ShoppingMallAdmin, confirmation_fields=["shops"])
+        self.setAdminAttributes(ShoppingMallAdmin, confirmation_fields=["shops"])
         shops = [ShopFactory() for i in range(3)]
         shopping_mall = ShoppingMall.objects.create(name="name")
         shopping_mall.refresh_from_db()
@@ -223,7 +222,7 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         self,
     ):
         # make the m2m the only confirmation_field
-        self.setAdminAttributes(shoppingmall_admin.ShoppingMallAdmin, confirmation_fields=["shops"])
+        self.setAdminAttributes(ShoppingMallAdmin, confirmation_fields=["shops"])
         shops = [ShopFactory() for i in range(3)]
         shopping_mall = ShoppingMall.objects.create(name="name")
         shopping_mall.shops.set(shops)
@@ -249,7 +248,7 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         self,
     ):
         # make the m2m the only confirmation_field
-        self.setAdminAttributes(shoppingmall_admin.ShoppingMallAdmin, confirmation_fields=["shops"])
+        self.setAdminAttributes(ShoppingMallAdmin, confirmation_fields=["shops"])
 
         self.selenium.get(self.live_server_url + f"/admin/market/shoppingmall/add/")
         self.assertIn(CONFIRM_ADD, self.selenium.page_source)
@@ -266,7 +265,7 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         self,
     ):
         # make the m2m the only confirmation_field
-        self.setAdminAttributes(shoppingmall_admin.ShoppingMallAdmin, confirmation_fields=["shops"])
+        self.setAdminAttributes(ShoppingMallAdmin, confirmation_fields=["shops"])
         shops = [ShopFactory() for i in range(3)]
 
         self.selenium.get(self.live_server_url + f"/admin/market/shoppingmall/add/")

--- a/admin_confirm/tests/integration/test_with_inlines.py
+++ b/admin_confirm/tests/integration/test_with_inlines.py
@@ -7,7 +7,6 @@ Does not test confirmation of inline changes
 
 import pytest
 import django
-from importlib import reload
 from tests.factories import ShopFactory
 from tests.market.models import GeneralManager, ShoppingMall, Town
 
@@ -27,10 +26,6 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
             shoppingmall_admin.ShoppingMallAdmin,
             inlines=[shoppingmall_admin.ShopInline],
         )
-
-    def tearDown(self):
-        reload(shoppingmall_admin)
-        super().tearDown()
 
     def test_should_have_hidden_form(self):
         mall = ShoppingMall.objects.create(name="mall")
@@ -118,10 +113,11 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         if django_major < 3:
             pytest.skip("get_inlines() introducted in Django 3.0, and is not in this version")
 
-        shoppingmall_admin.ShoppingMallAdmin.inlines = []
-        shoppingmall_admin.ShoppingMallAdmin.get_inlines = lambda self, request, obj=None: [
-            shoppingmall_admin.ShopInline
-        ]
+        self.setAdminAttributes(
+            shoppingmall_admin.ShoppingMallAdmin,
+            inlines=[],
+            get_inlines=lambda self, request, obj=None: [shoppingmall_admin.ShopInline],
+        )
 
         gm = GeneralManager.objects.create(name="gm")
         town = Town.objects.create(name="town")
@@ -153,11 +149,12 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         self.assertIn(shops[2], mall.shops.all())
 
     def test_should_respect_get_inline_instances(self):
-        shoppingmall_admin.ShoppingMallAdmin.inlines = []
-        shoppingmall_admin.ShoppingMallAdmin.get_inline_instances = (
-            lambda self, request, obj=None: shoppingmall_admin.ShopInline(
+        self.setAdminAttributes(
+            shoppingmall_admin.ShoppingMallAdmin,
+            inlines=[],
+            get_inline_instances=lambda self, request, obj=None: shoppingmall_admin.ShopInline(
                 self.model, self.admin_site
-            )
+            ),
         )
         gm = GeneralManager.objects.create(name="gm")
         town = Town.objects.create(name="town")

--- a/admin_confirm/tests/integration/test_with_inlines.py
+++ b/admin_confirm/tests/integration/test_with_inlines.py
@@ -4,6 +4,7 @@ on ModelAdmin that includes inlines
 
 Does not test confirmation of inline changes
 """
+
 import pytest
 import django
 from importlib import reload
@@ -21,8 +22,11 @@ from selenium.webdriver.common.by import By
 class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
     def setUp(self):
         self.admin = shoppingmall_admin.ShoppingMallAdmin
-        self.admin.inlines = [shoppingmall_admin.ShopInline]
         super().setUp()
+        self.setAdminAttributes(
+            shoppingmall_admin.ShoppingMallAdmin,
+            inlines=[shoppingmall_admin.ShopInline],
+        )
 
     def tearDown(self):
         reload(shoppingmall_admin)
@@ -30,9 +34,7 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
 
     def test_should_have_hidden_form(self):
         mall = ShoppingMall.objects.create(name="mall")
-        self.selenium.get(
-            self.live_server_url + f"/admin/market/shoppingmall/{mall.id}/change/"
-        )
+        self.selenium.get(self.live_server_url + f"/admin/market/shoppingmall/{mall.id}/change/")
         # Should ask for confirmation of change
         self.assertIn(CONFIRM_CHANGE, self.selenium.page_source)
 
@@ -62,9 +64,7 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         mall = ShoppingMall.objects.create(name="mall", general_manager=gm, town=town)
         mall.shops.set(shops)
 
-        self.selenium.get(
-            self.live_server_url + f"/admin/market/shoppingmall/{mall.id}/change/"
-        )
+        self.selenium.get(self.live_server_url + f"/admin/market/shoppingmall/{mall.id}/change/")
         self.assertIn(CONFIRM_CHANGE, self.selenium.page_source)
 
         # Make a change to trigger confirmation page
@@ -89,9 +89,7 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
 
         shops = [ShopFactory(name=i) for i in range(3)]
 
-        self.selenium.get(
-            self.live_server_url + f"/admin/market/shoppingmall/{mall.id}/change/"
-        )
+        self.selenium.get(self.live_server_url + f"/admin/market/shoppingmall/{mall.id}/change/")
         self.assertIn(CONFIRM_CHANGE, self.selenium.page_source)
 
         # Make a change to trigger confirmation page
@@ -99,9 +97,7 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         name.send_keys("New Name")
 
         # Change shops via inline form
-        select_shop = Select(
-            self.selenium.find_element(By.NAME, "ShoppingMall_shops-0-shop")
-        )
+        select_shop = Select(self.selenium.find_element(By.NAME, "ShoppingMall_shops-0-shop"))
         select_shop.select_by_value(str(shops[2].id))
 
         self.selenium.find_element(By.NAME, "_continue").click()
@@ -120,14 +116,12 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         # New in Django 3.0
         django_major = django.VERSION[0]
         if django_major < 3:
-            pytest.skip(
-                "get_inlines() introducted in Django 3.0, and is not in this version"
-            )
+            pytest.skip("get_inlines() introducted in Django 3.0, and is not in this version")
 
         shoppingmall_admin.ShoppingMallAdmin.inlines = []
-        shoppingmall_admin.ShoppingMallAdmin.get_inlines = (
-            lambda self, request, obj=None: [shoppingmall_admin.ShopInline]
-        )
+        shoppingmall_admin.ShoppingMallAdmin.get_inlines = lambda self, request, obj=None: [
+            shoppingmall_admin.ShopInline
+        ]
 
         gm = GeneralManager.objects.create(name="gm")
         town = Town.objects.create(name="town")
@@ -135,9 +129,7 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
 
         shops = [ShopFactory(name=i) for i in range(3)]
 
-        self.selenium.get(
-            self.live_server_url + f"/admin/market/shoppingmall/{mall.id}/change/"
-        )
+        self.selenium.get(self.live_server_url + f"/admin/market/shoppingmall/{mall.id}/change/")
         self.assertIn(CONFIRM_CHANGE, self.selenium.page_source)
 
         # Make a change to trigger confirmation page
@@ -145,9 +137,7 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         name.send_keys("New Name")
 
         # Change shops via inline form
-        select_shop = Select(
-            self.selenium.find_element(By.NAME, "ShoppingMall_shops-0-shop")
-        )
+        select_shop = Select(self.selenium.find_element(By.NAME, "ShoppingMall_shops-0-shop"))
         select_shop.select_by_value(str(shops[2].id))
 
         self.selenium.find_element(By.NAME, "_continue").click()
@@ -175,9 +165,7 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
 
         shops = [ShopFactory(name=i) for i in range(3)]
 
-        self.selenium.get(
-            self.live_server_url + f"/admin/market/shoppingmall/{mall.id}/change/"
-        )
+        self.selenium.get(self.live_server_url + f"/admin/market/shoppingmall/{mall.id}/change/")
         self.assertIn(CONFIRM_CHANGE, self.selenium.page_source)
 
         # Make a change to trigger confirmation page
@@ -185,9 +173,7 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         name.send_keys("New Name")
 
         # Change shops via inline form
-        select_shop = Select(
-            self.selenium.find_element(By.NAME, "ShoppingMall_shops-0-shop")
-        )
+        select_shop = Select(self.selenium.find_element(By.NAME, "ShoppingMall_shops-0-shop"))
         select_shop.select_by_value(str(shops[2].id))
 
         self.selenium.find_element(By.NAME, "_continue").click()

--- a/admin_confirm/tests/integration/test_with_inlines.py
+++ b/admin_confirm/tests/integration/test_with_inlines.py
@@ -11,7 +11,7 @@ from tests.factories import ShopFactory
 from tests.market.models import GeneralManager, ShoppingMall, Town
 
 from admin_confirm.tests.helpers import AdminConfirmIntegrationTestCase
-from tests.market.admin import ShoppingMallAdmin, ShopInline
+from tests.market.admin.shoppingmall_admin import ShoppingMallAdmin, ShopInline
 
 from admin_confirm.constants import CONFIRM_ADD, CONFIRM_CHANGE
 from selenium.webdriver.support.ui import Select

--- a/admin_confirm/tests/integration/test_with_inlines.py
+++ b/admin_confirm/tests/integration/test_with_inlines.py
@@ -14,7 +14,7 @@ from tests.market.models import GeneralManager, ShoppingMall, Town
 from admin_confirm.tests.helpers import AdminConfirmIntegrationTestCase
 from tests.market.admin import shoppingmall_admin
 
-from admin_confirm.constants import CONFIRM_CHANGE
+from admin_confirm.constants import CONFIRM_ADD, CONFIRM_CHANGE
 from selenium.webdriver.support.ui import Select
 from selenium.webdriver.common.by import By
 
@@ -222,7 +222,7 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         self.assertEqual(shopping_mall.shops.count(), 1)
         self.assertIn(shops[0], shopping_mall.shops.all())
 
-    def test_does_not_trigger_confirmation_if_m2m_field_in_confirmation_fields_but_m2m_field_not_changed(
+    def test_change_does_not_trigger_confirmation_if_m2m_field_in_confirmation_fields_but_m2m_field_not_changed(
         self,
     ):
         # make the m2m the only confirmation_field
@@ -247,3 +247,43 @@ class ConfirmWithInlinesTests(AdminConfirmIntegrationTestCase):
         # Shops has not changed
         shopping_mall.refresh_from_db()
         self.assertEqual(shopping_mall.shops.count(), 3)
+
+    def test_add_does_not_trigger_confirmation_if_m2m_field_in_confirmation_fields_but_m2m_field_not_changed(
+        self,
+    ):
+        # make the m2m the only confirmation_field
+        self.setAdminAttributes(shoppingmall_admin.ShoppingMallAdmin, confirmation_fields=["shops"])
+
+        self.selenium.get(self.live_server_url + f"/admin/market/shoppingmall/add/")
+        self.assertIn(CONFIRM_ADD, self.selenium.page_source)
+
+        # Fill in required fields, but do not change m2m field
+        name = self.selenium.find_element(By.NAME, "name")
+        name.send_keys("name")
+        self.selenium.find_element(By.NAME, "_continue").click()
+
+        # Should not ask for confirmation since m2m field has not changed
+        self.assertNotIn("Confirm", self.selenium.page_source)
+
+    def test_add_does_trigger_confirmation_if_m2m_field_in_confirmation_fields_and_changed_from_default(
+        self,
+    ):
+        # make the m2m the only confirmation_field
+        self.setAdminAttributes(shoppingmall_admin.ShoppingMallAdmin, confirmation_fields=["shops"])
+        shops = [ShopFactory() for i in range(3)]
+
+        self.selenium.get(self.live_server_url + f"/admin/market/shoppingmall/add/")
+        self.assertIn(CONFIRM_ADD, self.selenium.page_source)
+
+        # Fill in required fields
+        name = self.selenium.find_element(By.NAME, "name")
+        name.send_keys("name")
+
+        # Select a shop in the m2m field to change it from the default of empty
+        select_shop = Select(self.selenium.find_element(By.NAME, "shops"))
+        select_shop.select_by_value(str(shops[0].id))
+
+        self.selenium.find_element(By.NAME, "_continue").click()
+
+        # Should ask for confirmation since m2m field has changed from default
+        self.assertIn("Confirm", self.selenium.page_source)

--- a/admin_confirm/tests/integration/test_with_s3_storage.py
+++ b/admin_confirm/tests/integration/test_with_s3_storage.py
@@ -11,7 +11,6 @@ from importlib.metadata import version as get_version
 import localstack_client.session
 import django
 
-from importlib import reload
 from selenium.webdriver.remote.file_detector import LocalFileDetector
 from selenium.webdriver.common.by import By
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -47,7 +46,6 @@ class ConfirmWithS3StorageTests(AdminConfirmIntegrationTestCase):
         super().setUp()
 
     def tearDown(self):
-        reload(shoppingmall_admin)
         # Delete all current files
         for obj in self.bucket.objects.all():
             obj.delete()
@@ -71,12 +69,6 @@ class ConfirmWithS3StorageTests(AdminConfirmIntegrationTestCase):
             )
 
     def test_should_save_file_additions(self):
-        selenium_major = int(get_version("selenium").split(".")[0])
-        if selenium_major < 4:
-            pytest.skip(
-                "Known issue `https://github.com/SeleniumHQ/selenium/issues/8762` with this selenium version."
-            )
-
         item = Item.objects.create(name="item", price=1, currency=Item.VALID_CURRENCIES[0][0])
 
         self.selenium.get(self.live_server_url + f"/admin/market/item/{item.id}/change/")
@@ -110,12 +102,6 @@ class ConfirmWithS3StorageTests(AdminConfirmIntegrationTestCase):
         self.assertRegex(objects[0].key, r"screenshot.*\.png$")
 
     def test_should_save_file_changes(self):
-        selenium_major = int(get_version("selenium").split(".")[0])
-        if selenium_major < 4:
-            pytest.skip(
-                "Known issue `https://github.com/SeleniumHQ/selenium/issues/8762` with this selenium version."
-            )
-
         item = Item.objects.create(
             name="item", price=1, currency=Item.VALID_CURRENCIES[0][0], file=self.file
         )

--- a/admin_confirm/tests/integration/test_with_validators_integration.py
+++ b/admin_confirm/tests/integration/test_with_validators_integration.py
@@ -22,8 +22,11 @@ from tests.market.admin import shoppingmall_admin
 class ConfirmWithValidatorsTests(AdminConfirmIntegrationTestCase):
     def setUp(self):
         self.admin = shoppingmall_admin.ShoppingMallAdmin
-        self.admin.inlines = [shoppingmall_admin.ShopInline]
         super().setUp()
+        self.setAdminAttributes(
+            shoppingmall_admin.ShoppingMallAdmin,
+            inlines=[shoppingmall_admin.ShopInline],
+        )
 
     def tearDown(self):
         reload(shoppingmall_admin)

--- a/admin_confirm/tests/integration/test_with_validators_integration.py
+++ b/admin_confirm/tests/integration/test_with_validators_integration.py
@@ -2,7 +2,6 @@
 Ensures that confirmations work with validators on the Model and on the Modelform.
 """
 
-from importlib import reload
 from selenium.webdriver.common.by import By
 from unittest import mock
 
@@ -21,7 +20,6 @@ from tests.market.admin import shoppingmall_admin
 
 class ConfirmWithValidatorsTests(AdminConfirmIntegrationTestCase):
     def setUp(self):
-        self.admin = shoppingmall_admin.ShoppingMallAdmin
         super().setUp()
         self.setAdminAttributes(
             shoppingmall_admin.ShoppingMallAdmin,
@@ -29,7 +27,6 @@ class ConfirmWithValidatorsTests(AdminConfirmIntegrationTestCase):
         )
 
     def tearDown(self):
-        reload(shoppingmall_admin)
         super().tearDown()
 
     @mock.patch("tests.market.models.ItemSale.clean")

--- a/admin_confirm/tests/unit/test_confirm_change_and_add.py
+++ b/admin_confirm/tests/unit/test_confirm_change_and_add.py
@@ -15,7 +15,7 @@ from tests.factories import ItemFactory, ShopFactory, InventoryFactory
 @mock.patch.object(ShoppingMallAdmin, "inlines", [])
 class TestConfirmChangeAndAdd(AdminConfirmTestCase):
     def test_get_add_without_confirm_add(self):
-        ItemAdmin.confirm_add = False
+        self.setAdminAttributes(ItemAdmin, confirm_add=False)
         response = self.client.get(reverse("admin:market_item_add"))
         self.assertFalse(response.context_data.get("confirm_add"))
         self.assertNotIn("_confirm_add", response.rendered_content)
@@ -182,7 +182,7 @@ class TestConfirmChangeAndAdd(AdminConfirmTestCase):
 
     def test_get_confirmation_fields_respects___all__(self):
         expected_fields = [f.name for f in Item._meta.fields if f.name != "id"]
-        ItemAdmin.confirmation_fields = "__all__"
+        self.setAdminAttributes(ItemAdmin, confirmation_fields="__all__")
         admin = ItemAdmin(Item, AdminSite())
         actual_fields = admin.get_confirmation_fields(self.factory.request())
         for field in expected_fields:
@@ -190,8 +190,7 @@ class TestConfirmChangeAndAdd(AdminConfirmTestCase):
 
     def test_get_confirmation_fields_should_default_if_not_set(self):
         expected_fields = [f.name for f in Item._meta.fields if f.name != "id"]
-        ItemAdmin.confirmation_fields = None
-        ItemAdmin.fields = expected_fields
+        self.setAdminAttributes(ItemAdmin, confirmation_fields=None, fields=expected_fields)
         admin = ItemAdmin(Item, AdminSite())
         actual_fields = admin.get_confirmation_fields(self.factory.request())
         for field in expected_fields:
@@ -201,7 +200,7 @@ class TestConfirmChangeAndAdd(AdminConfirmTestCase):
         self,
     ):
         admin_fields = ["name", "price"]
-        ItemAdmin.confirmation_fields = None
+        self.setAdminAttributes(ItemAdmin, confirmation_fields=None)
         with mock.patch.object(ItemAdmin, "fields", admin_fields):
             admin = ItemAdmin(Item, AdminSite())
             actual_fields = admin.get_confirmation_fields(self.factory.request())
@@ -209,14 +208,14 @@ class TestConfirmChangeAndAdd(AdminConfirmTestCase):
 
     def test_get_confirmation_fields_if_set(self):
         expected_fields = ["name", "currency"]
-        ItemAdmin.confirmation_fields = expected_fields
+        self.setAdminAttributes(ItemAdmin, confirmation_fields=expected_fields)
         admin = ItemAdmin(Item, AdminSite())
         actual_fields = admin.get_confirmation_fields(self.factory.request())
         self.assertCountEqual(expected_fields, actual_fields)
 
     def test_get_confirmation_fields_if_set_with_invalid_field(self):
         set_fields = ["name", "currency", "invalid_field"]
-        ItemAdmin.confirmation_fields = set_fields
+        self.setAdminAttributes(ItemAdmin, confirmation_fields=set_fields)
         admin = ItemAdmin(Item, AdminSite())
         actual_fields = admin.get_confirmation_fields(self.factory.request())
         expected_fields = ["name", "currency"]  # should ignore invalid field
@@ -224,7 +223,7 @@ class TestConfirmChangeAndAdd(AdminConfirmTestCase):
 
     def test_get_confirmation_fields_for_admin_with_custom_fields(self):
         expected_fields = [f.name for f in Transaction._meta.fields if f.name != "id"]
-        TransactionAdmin.confirmation_fields = "__all__"
+        self.setAdminAttributes(TransactionAdmin, confirmation_fields="__all__")
         admin = TransactionAdmin(Transaction, AdminSite())
         actual_fields = admin.get_confirmation_fields(self.factory.request())
         self.assertCountEqual(expected_fields, actual_fields)

--- a/admin_confirm/tests/unit/test_confirm_change_and_add_m2m_field.py
+++ b/admin_confirm/tests/unit/test_confirm_change_and_add_m2m_field.py
@@ -10,9 +10,19 @@ from tests.factories import ShopFactory
 
 @mock.patch.object(ShoppingMallAdmin, "inlines", [])
 class TestConfirmChangeAndAddM2MField(AdminConfirmTestCase):
+    """
+    These unit tests bypass the confirmation page and directly test
+    what clicking "Yes, I'm sure" on the confirmation page would do
+    for add and change with M2M fields
+
+    They do not test that the confirmation page gets rendered,
+    for that see the integration tests.
+    """
+
     def test_post_add_without_confirm_add_m2m(self):
         shops = [ShopFactory() for i in range(3)]
 
+        # Should be able to add without confirmation if _confirm_add not sent even if m2m field is in confirmation_fields
         data = {"name": "name", "shops": [s.id for s in shops]}
         response = self.client.post(reverse("admin:market_shoppingmall_add"), data)
         # Redirects to changelist and is added
@@ -66,7 +76,7 @@ class TestConfirmChangeAndAddM2MField(AdminConfirmTestCase):
         shops = [ShopFactory() for i in range(10)]
         shopping_mall = ShoppingMall.objects.create(name="My Mall")
         shopping_mall.shops.set(shops)
-        # Currently ShoppingMall configured with confirmation_fields = ['name']
+
         data = {
             "name": "Not My Mall",
             "shops": [1, 2],
@@ -115,7 +125,7 @@ class TestConfirmChangeAndAddM2MField(AdminConfirmTestCase):
         shops = [ShopFactory() for i in range(10)]
         shopping_mall = ShoppingMall.objects.create(name="My Mall")
         shopping_mall.shops.set(shops)
-        # Currently ShoppingMall configured with confirmation_fields = ['name']
+
         data = {
             "name": "Not My Mall",
             "shops": [1, 2, 3],
@@ -146,6 +156,8 @@ class TestConfirmChangeAndAddM2MField(AdminConfirmTestCase):
         shopping_mall.shops.set(shops)
         assert shopping_mall.shops.count() == 3
 
+        # _confirm_change not sent even though m2m field is in confirmation_fields
+        # Should be able to post change without confirmation if _confirm_change not sent
         data = {"name": "name", "id": str(shopping_mall.id), "shops": ["1"]}
         response = self.client.post(f"/admin/market/shoppingmall/{shopping_mall.id}/change/", data)
         # Redirects to changelist

--- a/admin_confirm/tests/unit/test_confirm_change_and_add_m2m_field.py
+++ b/admin_confirm/tests/unit/test_confirm_change_and_add_m2m_field.py
@@ -1,5 +1,6 @@
 from unittest import mock
 from django.urls import reverse
+from django.contrib.admin import AdminSite
 
 from admin_confirm.tests.helpers import AdminConfirmTestCase
 from tests.market.admin import ShoppingMallAdmin
@@ -192,3 +193,13 @@ class TestConfirmChangeAndAddM2MField(AdminConfirmTestCase):
         # Should not have updated inventory
         shopping_mall.refresh_from_db()
         self.assertEqual(shopping_mall.shops.count(), 0)
+
+    def test_get_confirmation_fields_includes_m2m_fields(self):
+        # Create a mock admin instance
+        admin = ShoppingMallAdmin(ShoppingMall, AdminSite())
+
+        # Call get_confirmation_fields
+        confirmation_fields = admin.get_confirmation_fields(self.factory.request())
+
+        # Assert that the M2M field 'shops' is included
+        self.assertIn("shops", confirmation_fields)

--- a/admin_confirm/tests/unit/test_confirm_change_and_add_m2m_field.py
+++ b/admin_confirm/tests/unit/test_confirm_change_and_add_m2m_field.py
@@ -22,7 +22,7 @@ class TestConfirmChangeAndAddM2MField(AdminConfirmTestCase):
         self.assertEqual(ShoppingMall.objects.all().first().shops.count(), 3)
 
     def test_post_add_with_confirm_add_m2m(self):
-        ShoppingMallAdmin.confirmation_fields = ["shops"]
+        self.setAdminAttributes(ShoppingMallAdmin, confirmation_fields=["shops"])
         shops = [ShopFactory() for i in range(3)]
 
         data = {
@@ -75,9 +75,7 @@ class TestConfirmChangeAndAddM2MField(AdminConfirmTestCase):
             "csrfmiddlewaretoken": "fake token",
             "_continue": True,
         }
-        response = self.client.post(
-            f"/admin/market/shoppingmall/{shopping_mall.id}/change/", data
-        )
+        response = self.client.post(f"/admin/market/shoppingmall/{shopping_mall.id}/change/", data)
         # Ensure not redirected (confirmation page does not redirect)
         self.assertEqual(response.status_code, 200)
         expected_templates = [
@@ -95,9 +93,7 @@ class TestConfirmChangeAndAddM2MField(AdminConfirmTestCase):
             options=shops,
             selected_ids=data["shops"],
         )
-        self._assertSubmitHtml(
-            rendered_content=response.rendered_content, save_action="_continue"
-        )
+        self._assertSubmitHtml(rendered_content=response.rendered_content, save_action="_continue")
 
         # Hasn't changed item yet
         shopping_mall.refresh_from_db()
@@ -106,14 +102,10 @@ class TestConfirmChangeAndAddM2MField(AdminConfirmTestCase):
         # Selecting to "Yes, I'm sure" on the confirmation page
         # Would post to the same endpoint
         del data["_confirm_change"]
-        response = self.client.post(
-            f"/admin/market/shoppingmall/{shopping_mall.id}/change/", data
-        )
+        response = self.client.post(f"/admin/market/shoppingmall/{shopping_mall.id}/change/", data)
         # will show the change page for this shopping_mall
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(
-            response.url, f"/admin/market/shoppingmall/{shopping_mall.id}/change/"
-        )
+        self.assertEqual(response.url, f"/admin/market/shoppingmall/{shopping_mall.id}/change/")
         # Should not be the confirmation page, we already confirmed change
         self.assertNotEqual(response.templates, expected_templates)
         self.assertEqual(ShoppingMall.objects.count(), 1)
@@ -132,9 +124,7 @@ class TestConfirmChangeAndAddM2MField(AdminConfirmTestCase):
             "csrfmiddlewaretoken": "fake token",
             "_save": True,
         }
-        response = self.client.post(
-            f"/admin/market/shoppingmall/{shopping_mall.id}/change/", data
-        )
+        response = self.client.post(f"/admin/market/shoppingmall/{shopping_mall.id}/change/", data)
         # Ensure not redirected (confirmation page does not redirect)
         self.assertEqual(response.status_code, 200)
         expected_templates = [
@@ -150,16 +140,14 @@ class TestConfirmChangeAndAddM2MField(AdminConfirmTestCase):
 
     def test_post_change_without_confirm_change_m2m_value(self):
         # make the m2m the confirmation_field
-        ShoppingMallAdmin.confirmation_fields = ["shops"]
+        self.setAdminAttributes(ShoppingMallAdmin, confirmation_fields=["shops"])
         shops = [ShopFactory() for i in range(3)]
         shopping_mall = ShoppingMall.objects.create(name="name")
         shopping_mall.shops.set(shops)
         assert shopping_mall.shops.count() == 3
 
         data = {"name": "name", "id": str(shopping_mall.id), "shops": ["1"]}
-        response = self.client.post(
-            f"/admin/market/shoppingmall/{shopping_mall.id}/change/", data
-        )
+        response = self.client.post(f"/admin/market/shoppingmall/{shopping_mall.id}/change/", data)
         # Redirects to changelist
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, "/admin/market/shoppingmall/")
@@ -168,7 +156,7 @@ class TestConfirmChangeAndAddM2MField(AdminConfirmTestCase):
         self.assertEqual(shopping_mall.shops.count(), 1)
 
     def test_form_invalid_m2m_value(self):
-        ShoppingMallAdmin.confirmation_fields = ["shops"]
+        self.setAdminAttributes(ShoppingMallAdmin, confirmation_fields=["shops"])
         shopping_mall = ShoppingMall.objects.create(name="name")
 
         data = {
@@ -178,17 +166,13 @@ class TestConfirmChangeAndAddM2MField(AdminConfirmTestCase):
             "_confirm_change": True,
             "csrfmiddlewaretoken": "fake token",
         }
-        response = self.client.post(
-            f"/admin/market/shoppingmall/{shopping_mall.id}/change/", data
-        )
+        response = self.client.post(f"/admin/market/shoppingmall/{shopping_mall.id}/change/", data)
 
         # Form invalid should show errors on form
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(response.context_data.get("errors"))
         self.assertTrue(
-            str(response.context_data["errors"][0][0]).startswith(
-                "Select a valid choice."
-            )
+            str(response.context_data["errors"][0][0]).startswith("Select a valid choice.")
         )
         # Should not have updated inventory
         shopping_mall.refresh_from_db()

--- a/admin_confirm/tests/unit/test_confirm_save_actions.py
+++ b/admin_confirm/tests/unit/test_confirm_save_actions.py
@@ -21,7 +21,7 @@ class TestConfirmSaveActions(AdminConfirmTestCase):
 
     def test_simple_add_with_save(self):
         # Load the Add Item Page
-        ItemAdmin.confirm_add = True
+        self.setAdminAttributes(ItemAdmin, confirm_add=True)
         response = self.client.get(reverse("admin:market_item_add"))
 
         # Should be asked for confirmation
@@ -80,7 +80,7 @@ class TestConfirmSaveActions(AdminConfirmTestCase):
         item = ItemFactory(name="Not name")
 
         # Load the Change Item Page
-        ItemAdmin.confirm_change = True
+        self.setAdminAttributes(ItemAdmin, confirm_change=True)
         response = self.client.get(f"/admin/market/item/{item.id}/change/")
 
         # Should be asked for confirmation
@@ -135,7 +135,7 @@ class TestConfirmSaveActions(AdminConfirmTestCase):
 
     def test_file_and_image_add_addanother(self):
         # Load the Add Item Page
-        ItemAdmin.confirm_add = True
+        self.setAdminAttributes(ItemAdmin, confirm_add=True)
         response = self.client.get(reverse("admin:market_item_add"))
 
         # Should be asked for confirmation
@@ -223,10 +223,13 @@ class TestConfirmSaveActions(AdminConfirmTestCase):
         item.save()
 
         # Load the Change Item Page
-        ItemAdmin.confirm_change = True
-        ItemAdmin.fields = ["name", "price", "file", "image", "currency"]
-        ItemAdmin.save_as = True
-        ItemAdmin.save_as_continue = True
+        self.setAdminAttributes(
+            ItemAdmin,
+            confirm_change=True,
+            fields=["name", "price", "file", "image", "currency"],
+            save_as=True,
+            save_as_continue=True,
+        )
         response = self.client.get(f"/admin/market/item/{item.id}/change/")
 
         # Should be asked for confirmation
@@ -303,7 +306,7 @@ class TestConfirmSaveActions(AdminConfirmTestCase):
         town = Town.objects.create(name="town")
 
         # Load the Add ShoppingMall Page
-        ShoppingMallAdmin.confirm_add = True
+        self.setAdminAttributes(ShoppingMallAdmin, confirm_add=True)
         response = self.client.get(reverse("admin:market_shoppingmall_add"))
 
         # Should be asked for confirmation
@@ -373,7 +376,7 @@ class TestConfirmSaveActions(AdminConfirmTestCase):
         town2 = Town.objects.create(name="town2")
 
         # Load the Change ShoppingMall Page
-        ShoppingMallAdmin.confirm_change = True
+        self.setAdminAttributes(ShoppingMallAdmin, confirm_change=True)
         response = self.client.get(f"/admin/market/shoppingmall/{mall.id}/change/")
 
         # Should be asked for confirmation

--- a/admin_confirm/tests/unit/test_confirmation_cache.py
+++ b/admin_confirm/tests/unit/test_confirmation_cache.py
@@ -21,7 +21,7 @@ class TestConfirmationCache(AdminConfirmTestCase):
 
     def test_simple_add(self):
         # Load the Add Item Page
-        ItemAdmin.confirm_add = True
+        self.setAdminAttributes(ItemAdmin, confirm_add=True)
         response = self.client.get(reverse("admin:market_item_add"))
 
         # Should be asked for confirmation
@@ -80,7 +80,7 @@ class TestConfirmationCache(AdminConfirmTestCase):
         item = ItemFactory(name="Not name")
 
         # Load the Change Item Page
-        ItemAdmin.confirm_change = True
+        self.setAdminAttributes(ItemAdmin, confirm_change=True)
         response = self.client.get(f"/admin/market/item/{item.id}/change/")
 
         # Should be asked for confirmation
@@ -135,7 +135,7 @@ class TestConfirmationCache(AdminConfirmTestCase):
 
     def test_file_and_image_add(self):
         # Load the Add Item Page
-        ItemAdmin.confirm_add = True
+        self.setAdminAttributes(ItemAdmin, confirm_add=True)
         response = self.client.get(reverse("admin:market_item_add"))
 
         # Should be asked for confirmation
@@ -231,8 +231,9 @@ class TestConfirmationCache(AdminConfirmTestCase):
         item.save()
 
         # Load the Change Item Page
-        ItemAdmin.confirm_change = True
-        ItemAdmin.fields = ["name", "price", "file", "image", "currency"]
+        self.setAdminAttributes(
+            ItemAdmin, confirm_change=True, fields=["name", "price", "file", "image", "currency"]
+        )
         response = self.client.get(f"/admin/market/item/{item.id}/change/")
 
         # Should be asked for confirmation
@@ -307,7 +308,7 @@ class TestConfirmationCache(AdminConfirmTestCase):
         town = Town.objects.create(name="town")
 
         # Load the Add ShoppingMall Page
-        ShoppingMallAdmin.confirm_add = True
+        self.setAdminAttributes(ShoppingMallAdmin, confirm_add=True)
         response = self.client.get(reverse("admin:market_shoppingmall_add"))
 
         # Should be asked for confirmation
@@ -378,7 +379,7 @@ class TestConfirmationCache(AdminConfirmTestCase):
         town2 = Town.objects.create(name="town2")
 
         # Load the Change ShoppingMall Page
-        ShoppingMallAdmin.confirm_change = True
+        self.setAdminAttributes(ShoppingMallAdmin, confirm_change=True)
         response = self.client.get(f"/admin/market/shoppingmall/{mall.id}/change/")
 
         # Should be asked for confirmation

--- a/admin_confirm/tests/unit/test_confirmation_using_file_cache.py
+++ b/admin_confirm/tests/unit/test_confirmation_using_file_cache.py
@@ -29,11 +29,6 @@ from tests.factories import ItemFactory, ShopFactory
 
 class TestConfirmationUsingFileCache(AdminConfirmTestCase):
     def setUp(self):
-        # Load the Change Item Page
-        ItemAdmin.confirm_change = True
-        ItemAdmin.fields = ["name", "price", "file", "image", "currency"]
-        ItemAdmin.save_as = True
-        ItemAdmin.save_as_continue = True
 
         self.image_path = "screenshot.png"
         with open(self.image_path, "rb") as f:
@@ -51,12 +46,20 @@ class TestConfirmationUsingFileCache(AdminConfirmTestCase):
         )
         self.item = ItemFactory(name="Not name", file=f, image=i)
 
-        return super().setUp()
+        super().setUp()
+        # Load the Change Item Page
+        self.setAdminAttributes(
+            ItemAdmin,
+            confirm_change=True,
+            fields=["name", "price", "file", "image", "currency"],
+            save_as=True,
+            save_as_continue=True,
+        )
 
     def test_save_as_continue_true_should_not_redirect_to_changelist(self):
         item = self.item
         # Load the Change Item Page
-        ItemAdmin.save_as_continue = True
+        self.setAdminAttributes(ItemAdmin, save_as_continue=True)
 
         # Upload new image and remove file
         i2 = SimpleUploadedFile(
@@ -129,7 +132,7 @@ class TestConfirmationUsingFileCache(AdminConfirmTestCase):
     def test_save_as_continue_false_should_redirect_to_changelist(self):
         item = self.item
         # Load the Change Item Page
-        ItemAdmin.save_as_continue = False
+        self.setAdminAttributes(ItemAdmin, save_as_continue=False)
 
         # Upload new image and remove file
         i2 = SimpleUploadedFile(
@@ -508,7 +511,7 @@ class TestConfirmationUsingFileCache(AdminConfirmTestCase):
     def test_change_without_cached_post_should_save_file_changes(self):
         item = self.item
         # Load the Change Item Page
-        ItemAdmin.save_as_continue = False
+        self.setAdminAttributes(ItemAdmin, save_as_continue=False)
 
         # Upload new image and remove file
         i2 = SimpleUploadedFile(
@@ -588,7 +591,7 @@ class TestConfirmationUsingFileCache(AdminConfirmTestCase):
     def test_change_without_cached_object_should_save_but_without_file_changes(self):
         item = self.item
         # Load the Change Item Page
-        ItemAdmin.save_as_continue = False
+        self.setAdminAttributes(ItemAdmin, save_as_continue=False)
 
         # Request.POST
         data = {
@@ -647,7 +650,7 @@ class TestConfirmationUsingFileCache(AdminConfirmTestCase):
     def test_change_without_any_cache_should_save_but_not_have_file_changes(self):
         item = self.item
         # Load the Change Item Page
-        ItemAdmin.save_as_continue = False
+        self.setAdminAttributes(ItemAdmin, save_as_continue=False)
 
         # Request.POST
         data = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,15 +8,7 @@ twine~=6.2.0
 coveralls~=3.0.0
 Pillow~=10.4.0 # For ImageField
 wheel~=0.45.1
-
-### SELENIUM ###
-# Known issue: https://github.com/SeleniumHQ/selenium/issues/8762
-# Python 3.6 should use because selenium 4 doesn't work with py3.6
-# selenium~=3.141.0
-
-# Others should use
-selenium~=4.0.0.a5
-### END SELENIUM ###
+selenium~=4.0.0.a7
 
 ### S3 ###
 localstack~=1.0.0 # For testing with S3

--- a/tests/market/admin/shoppingmall_admin.py
+++ b/tests/market/admin/shoppingmall_admin.py
@@ -17,7 +17,6 @@ class ShopInline(StackedInline):
 class ShoppingMallAdmin(AdminConfirmMixin, ModelAdmin):
     confirm_add = True
     confirm_change = True
-    confirmation_fields = ["name"]
 
     inlines = [ShopInline]
     raw_id_fields = ["general_manager"]

--- a/tests/market/admin/shoppingmall_admin.py
+++ b/tests/market/admin/shoppingmall_admin.py
@@ -1,7 +1,6 @@
 """ShoppingMallAdmin tests:
 - confirm_add and confirm_change should work when inlines are present and with raw_id_fields
-Note: Currently, the confirmation_fields only include fields from the main model, not from the inlines.
-    This test ensures that the presence of inlines and raw_id_fields does not interfere with the confirmation process for the main model.
+- default confirmation_fields should include inlines and trigger confirmation when M2M field changes
 """
 
 from ..models import ShoppingMall
@@ -17,7 +16,7 @@ class ShopInline(StackedInline):
 class ShoppingMallAdmin(AdminConfirmMixin, ModelAdmin):
     confirm_add = True
     confirm_change = True
-    confirmation_fields = ["name"]
+    confirmation_fields = "__all__"
 
     inlines = [ShopInline]
     raw_id_fields = ["general_manager"]

--- a/tests/market/admin/shoppingmall_admin.py
+++ b/tests/market/admin/shoppingmall_admin.py
@@ -1,6 +1,6 @@
 """ShoppingMallAdmin tests:
 - confirm_add and confirm_change should work when inlines are present and with raw_id_fields
-- default confirmation_fields should include inlines and trigger confirmation when M2M field changes
+- default confirmation_fields should include M2M fields and trigger confirmation when M2M field changes
 """
 
 from ..models import ShoppingMall

--- a/tests/market/admin/shoppingmall_admin.py
+++ b/tests/market/admin/shoppingmall_admin.py
@@ -17,6 +17,7 @@ class ShopInline(StackedInline):
 class ShoppingMallAdmin(AdminConfirmMixin, ModelAdmin):
     confirm_add = True
     confirm_change = True
+    confirmation_fields = ["name"]
 
     inlines = [ShopInline]
     raw_id_fields = ["general_manager"]


### PR DESCRIPTION
## Fixes 
#48 
- this PR aims to include M2M fields in default/'__all__'confirmation_fields and detect changes on the M2M fields.
- previously M2Mfield would always trigger confirmation even when not updated, this PR addresses that bug as well
- Out-of-scope: changes on inline triggering confirmation

## Proposed changes:
- Also add setAdminAttributes to test classes, which ensures that the Admins are returned to normal after test tearDown.
- Updated the AGENTS.md file


## Tested via:
- tested manually, but also added some tests
