### PR TITLE
fix(ISSUE-112): Validate inlines before render confirmation page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ test-all:
 	coverage run --source admin_confirm --branch -m pytest
 	coverage report -m
 
-t:
-	python -m pytest --last-failed -x
+dt:
+	docker compose -f docker-compose.dev.yml exec -T web python -m pytest --last-failed -x --pdb
 
 test-integration:
 	coverage run --source admin_confirm --branch -m pytest --ignore=admin_confirm/tests/unit

--- a/admin_confirm/admin.py
+++ b/admin_confirm/admin.py
@@ -9,8 +9,8 @@ from django.template.response import TemplateResponse
 from django.contrib.admin.options import TO_FIELD_VAR
 from django.utils.translation import gettext as _
 from django.contrib.admin import helpers
-from django.db.models import ForeignKey, Model, ManyToManyField, FileField, ImageField
-from django.forms import ModelForm
+from django.db.models import Model, ManyToManyField, FileField, ImageField
+from django.forms import ModelForm, all_valid
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control
 from admin_confirm.utils import (
@@ -371,7 +371,7 @@ class AdminConfirmMixin:
         # End code from super()._changeform_view
         # form.is_valid() checks both errors and "is_bound"
         # If form has errors, show the errors on the form instead of showing confirmation page
-        if not form_validated:
+        if not (all_valid(formsets) and form_validated):
             log("Invalid Form: return early")
             log(form.errors)
             # We must ensure that we ask for confirmation when showing errors

--- a/admin_confirm/tests/unit/test_with_validators.py
+++ b/admin_confirm/tests/unit/test_with_validators.py
@@ -5,7 +5,7 @@ NOTE: These unit tests are not enough to ensure that confirmations work with val
     Please ensure to add integration tests too!
 """
 
-from admin_confirm.constants import CONFIRM_ADD
+from admin_confirm.constants import CONFIRM_ADD, CONFIRM_CHANGE
 from unittest import mock
 from django.urls import reverse
 from django.utils import timezone
@@ -13,6 +13,7 @@ from django.utils import timezone
 from admin_confirm.tests.helpers import AdminConfirmTestCase
 from tests.market.models import Checkout, ItemSale
 from tests.factories import (
+    ConsumerFactory,
     InventoryFactory,
     ItemFactory,
     ShopFactory,
@@ -307,3 +308,48 @@ class TestWithValidators(AdminConfirmTestCase):
         self.assertIn("Invalid Total 222", str(response.rendered_content))
         # Should still ask for confirmation
         self.assertIn(CONFIRM_ADD, response.rendered_content)
+
+    def test_cannot_confirm_if_inline_has_errors(self):
+        consumer = ConsumerFactory(name="John Doe")
+        data = {
+            "consumer": consumer.id,
+            "name": "John McDowley",
+            "email": consumer.email,
+            "transactions-TOTAL_FORMS": "1",
+            "transactions-INITIAL_FORMS": ["0"],
+            "transactions-MIN_NUM_FORMS": ["0"],
+            "transactions-MAX_NUM_FORMS": ["1000"],
+            "transactions-0-id": ["12"],
+            "transactions-0-consumer": [f"consumer_{consumer.id}"],
+            "transactions-0-timestamp_0": ["2026-06-07"],
+            "transactions-0-timestamp_1": ["23:10:49"],
+            "transactions-0-total": ["12"],
+            "transactions-0-currency": ["USD"],
+            "transactions-0-shop": [""],  # Required
+            "transactions-0-date": ["2026-06-07"],
+            "transactions-__prefix__-id": [""],
+            "transactions-__prefix__-consumer": [f"consumer_{consumer.id}"],
+            "transactions-__prefix__-timestamp_0": [""],
+            "transactions-__prefix__-timestamp_1": [""],
+            "transactions-__prefix__-total": ["0"],
+            "transactions-__prefix__-currency": [""],
+            "transactions-__prefix__-shop": [""],
+            "transactions-__prefix__-date": [""],
+            "_confirm_change": ["True"],
+            "_save": ["Save"],
+        }
+        response = self.client.post(
+            reverse("admin:market_consumer_change", args=[consumer.id]), data
+        )
+        # Should show form with error and not confirmation page
+        self.assertEqual(response.status_code, 200)
+        expected_templates = [
+            "admin/market/consumer/change_form.html",
+            "admin/market/change_form.html",
+            "admin/change_form.html",
+        ]
+        self.assertEqual(response.template_name, expected_templates)
+        self.assertIn("error", str(response.rendered_content))
+        self.assertIn("This field is required", str(response.rendered_content))
+        # Should still ask for confirmation
+        self.assertIn(CONFIRM_CHANGE, response.rendered_content)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -41,3 +41,11 @@ class TransactionFactory(factory.django.DjangoModelFactory):
     date = factory.LazyAttribute(lambda _: timezone.now().date())
     timestamp = factory.LazyAttribute(lambda _: timezone.now())
     shop = factory.SubFactory(ShopFactory)
+
+
+class ConsumerFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = "market.Consumer"
+
+    name = factory.Faker("name")
+    email = factory.Faker("email")

--- a/tests/market/admin/consumer_admin.py
+++ b/tests/market/admin/consumer_admin.py
@@ -4,6 +4,12 @@
 
 from django.contrib import admin
 from admin_confirm.admin import AdminConfirmMixin
+from ..models import Transaction
+
+
+class TransactionInline(admin.TabularInline):
+    model = Transaction
+    extra = 0
 
 
 class ConsumerAdmin(AdminConfirmMixin, admin.ModelAdmin):
@@ -13,3 +19,4 @@ class ConsumerAdmin(AdminConfirmMixin, admin.ModelAdmin):
 
     confirm_change = True
     confirmation_fields = ["name"]
+    inlines = [TransactionInline]


### PR DESCRIPTION
## Fixes 
- #112 

## Proposed changes:
- Also validates inline forms prior to showing the confirmation page.
- Note: does not add confirmation on inline add/change
-

## Tested via:
- manually and added unit test
