### PR TITLE
chore: Fix test project's S3 settings for static URL

### DIFF
--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -3,15 +3,13 @@ services:
     extends:
       file: docker-compose.dev.yml
       service: web
-    # Note: collectstatic runs from inside the docker container and needs
-    #       to access localstack through the host machine using host.docker.internal
-    #       BUT when we access the django server from our host machine, we need to access
-    #       the stored staticfiles via localhost, so export LOCALSTACK_HOST before and after
+    # Keep internal and public LocalStack hosts split so collectstatic, uploads,
+    # and browser asset URLs all work in docker debug mode.
     command: >
       sh -c "export LOCALSTACK_HOST=host.docker.internal &&
+             export LOCALSTACK_PUBLIC_HOST=localhost &&
              python tests/manage.py collectstatic --no-input &&
              export PYDEVD_DISABLE_FILE_VALIDATION=1 &&
-             export LOCALSTACK_HOST=localhost &&
              python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:5678 --wait-for-client tests/manage.py runserver 0.0.0.0:8000"
     ports:
       - "5678:5678" # debugpy

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,14 +7,12 @@ services:
         PYTHON_VERSION: "$PYTHON_VERSION"
         DJANGO_VERSION: "$DJANGO_VERSION"
         SELENIUM_VERSION: "$SELENIUM_VERSION"
-    # Note: collectstatic runs from inside the docker container and needs
-    #       to access localstack through the host machine using host.docker.internal
-    #       BUT when we access the django server from our host machine, we need to access
-    #       the stored staticfiles via localhost, so export LOCALSTACK_HOST before and after
+    # Note: keep LOCALSTACK_HOST on host.docker.internal for container-side writes,
+    #       and use LOCALSTACK_PUBLIC_HOST=localhost so browser URLs are host-reachable.
     command: >
       sh -c "export LOCALSTACK_HOST=host.docker.internal &&
+             export LOCALSTACK_PUBLIC_HOST=localhost &&
              python tests/manage.py collectstatic --no-input &&
-             export LOCALSTACK_HOST=localhost &&
              python tests/manage.py runserver 0.0.0.0:8000"
     volumes:
       - .:/code
@@ -25,6 +23,7 @@ services:
       - localstack
     environment:
       - LOCALSTACK_HOST=host.docker.internal
+      - LOCALSTACK_PUBLIC_HOST=localhost
       - SELENIUM_HOST=host.docker.internal
 
   selenium:

--- a/tests/test_project/settings/base.py
+++ b/tests/test_project/settings/base.py
@@ -123,6 +123,7 @@ USE_TZ = True
 # and can be accessed at localhost. See: https://docs.github.com/en/actions/guides/about-service-containers#communicating-with-service-containers
 
 LOCALSTACK_HOST = os.getenv("LOCALSTACK_HOST", "localhost")
+LOCALSTACK_PUBLIC_HOST = os.getenv("LOCALSTACK_PUBLIC_HOST", LOCALSTACK_HOST)
 SELENIUM_HOST = os.getenv("SELENIUM_HOST", "localhost")
 
 # Static files (CSS, JavaScript, Images)
@@ -137,11 +138,15 @@ USE_S3 = os.getenv("USE_S3", "true").lower() == "true"
 if USE_S3:
     # aws settings
     AWS_S3_ENDPOINT_URL = f"http://{LOCALSTACK_HOST}:4566"
+    AWS_S3_PUBLIC_URL = f"http://{LOCALSTACK_PUBLIC_HOST}:4566"
     AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "test")
     AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "test")
     AWS_STORAGE_BUCKET_NAME = os.getenv("AWS_STORAGE_BUCKET_NAME", "mybucket")
     AWS_DEFAULT_ACL = None
-    # AWS_S3_CUSTOM_DOMAIN = f"{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com"
+    # Used by django-storages to determine the URL of the static files
+    AWS_S3_CUSTOM_DOMAIN = f"{LOCALSTACK_PUBLIC_HOST}:4566/{AWS_STORAGE_BUCKET_NAME}"
+    AWS_S3_URL_PROTOCOL = "http:"
+    AWS_QUERYSTRING_AUTH = False
     AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "max-age=86400"}
 
     if DJANGO_VERSION >= "4.2":
@@ -168,10 +173,10 @@ if USE_S3:
         DEFAULT_FILE_STORAGE = "tests.storage_backends.PublicMediaStorage"
 
     # s3 static settings
-    STATIC_URL = f"{AWS_S3_ENDPOINT_URL}/staticfiles/"
+    STATIC_URL = f"{AWS_S3_PUBLIC_URL}/staticfiles/"
     STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
     # s3 public media settings
-    MEDIA_URL = f"{AWS_S3_ENDPOINT_URL}/mediafiles/"
+    MEDIA_URL = f"{AWS_S3_PUBLIC_URL}/mediafiles/"
     MEDIA_ROOT = os.path.join(BASE_DIR, "mediafiles")
 
 else:


### PR DESCRIPTION
## Fixes 
- Previously the docker setup was switching the LOCALSTACK_HOST such that static files could be reached when accessing admin in local browser while it was running within docker. The issue was that this caused file uploads to fail as file upload would be a docker web container communication to localstack and thus needs to reach it from the host.docker.internal. This splits the env var such that there's a public localstack host. 

## Tested via:
- manually
